### PR TITLE
Selector del menú principal

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -27,20 +27,21 @@ struct Nube {
     float capa;
 };
 
-struct selector {
-    float posx;
-    float posy;
+struct Selector {
+    float posx = 178;
+    float posy = 140;
 
-    enum opcion{
+    enum Opcion {
     JUGAR,
     OPCIONES,
     CONTROLES,
     CREDITOS
     };
+
+    Opcion opcionActual = JUGAR;
 };
 
 class Menu {
-
 public:
 
     Letra titulo[6] = {{0,0,-2.0},{0,0,-2.1},{0,0,-2.2},{0,0,-2.3},{0,0,-2.4},{0,0,-2.5}};
@@ -48,13 +49,15 @@ public:
     Paloma paloma;
     Nube nube[2] = {{0,210,-1}, {240,210,-1.1} };
 
-
     float dt;
     float anguloLetras{};
     double ancho = 480;
     double alto = 270;
+    Selector selector;
 
     void actualizar(float dt);
     void dibujar(Renderizador* motor);
+    void moverSelector(int direccion);
+    Selector::Opcion getOpcionActual() { return selector.opcionActual; }
 };
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -31,13 +31,10 @@ struct Selector {
     float posx = 178;
     float posy = 140;
 
-    enum Opcion {
-    JUGAR,
-    OPCIONES,
-    CONTROLES,
-    CREDITOS
-    };
+    float tamano_base = 16.0f;
+    float tamano_actual = 16.0f;
 
+    enum Opcion { JUGAR, OPCIONES, CONTROLES, CREDITOS };
     Opcion opcionActual = JUGAR;
 };
 
@@ -50,7 +47,7 @@ public:
     Nube nube[2] = {{0,210,-1}, {240,210,-1.1} };
 
     float dt;
-    float anguloLetras{};
+    float angulo{};
     double ancho = 480;
     double alto = 270;
     Selector selector;

--- a/include/tablero.h
+++ b/include/tablero.h
@@ -22,7 +22,7 @@ public:
     void seleccionarCasillaJ2();
 
     void inicializarTablero();
-    void dibujarTablero();
+    void dibujarTablero(Renderizador* motor);
     bool obtenerCasillaEnLaPinchamos(int XPantalla, int YPantalla, int& Fila, int& Columna);
 
     void colocarPieza(int Fila, int Columna, Animal* Pieza);

--- a/src/juego.cpp
+++ b/src/juego.cpp
@@ -66,9 +66,10 @@ void Juego::renderizarGraficos() {
         break;
 
     case TABLERO:  
+        miTablero->dibujarTablero(motorGrafico);
 
         for (int i = 0; i < 10; i++) // LO MISMO QUE ARRIBA DENTRO DE DIBUJAR TABLERO
-        misAnimales[i]->dibujar(motorGrafico);
+        misAnimales[i]->dibujar(motorGrafico); // palomas de prueba
         break;
 
     case BATALLA:

--- a/src/juego.cpp
+++ b/src/juego.cpp
@@ -79,10 +79,29 @@ void Juego::renderizarGraficos() {
 
 void Juego::procesarTeclaPresionada(unsigned char key) // JUGADOR 1 (WASD)
 {
-    // Esc siempre cierra el juego, aunque en un futuro molaría poner un menú de pausa
-    if (key == 27) exit(0); 
+    if (key == 27) exit(0); // Esc siempre cierra el juego, aunque en un futuro molaría poner un menú de pausa
 
     switch (estadoActual) {
+
+    case MENU:
+        if (key == 13) { // Intro para elegir una opción
+            switch (miMenu->getOpcionActual()) {
+
+            case Selector::JUGAR: // de momento al elegir JUGAR pasa directamente al TABLERO, falta una pantalla para elegir bando etc.
+                estadoActual = TABLERO;
+
+            case Selector::OPCIONES: // en opciones puede estar el volumen o quizá algo del juego
+                //estadoActual = OPCIONES;
+
+            case Selector::CONTROLES: // en principio muestra nuestros controles, quizá se puedan elegir los tuyos propios
+                //estadoActual = CONTROLES;
+
+            case Selector::CREDITOS:
+                //estadoActual = CREDITOS;
+                break;
+            }
+        }
+
     case TABLERO: // movimiento discreto en el tablero
         if (key == 'w' || key == 'W') miTablero->moverCursorJ1(0, 1);
         if (key == 's' || key == 'S') miTablero->moverCursorJ1(0, -1);
@@ -117,6 +136,11 @@ void Juego::procesarTeclaLevantada(unsigned char key)
 void Juego::procesarTeclaEspecialPresionada(int key) // JUGADOR 2 (FLECHAS)
 {
     switch (estadoActual) {
+    case MENU:
+        if (key == GLUT_KEY_UP) miMenu->moverSelector(-1); // arriba resta 1 (se acerca a 0 que es JUGAR)
+        if (key == GLUT_KEY_DOWN) miMenu->moverSelector(1); // abajo suma 1 (bajándo hacia el 3 que es CREDITOS)
+        break;
+
     case TABLERO:
         if (key == GLUT_KEY_UP)    miTablero->moverCursorJ2(0, 1);
         if (key == GLUT_KEY_DOWN)  miTablero->moverCursorJ2(0, -1);

--- a/src/juego.cpp
+++ b/src/juego.cpp
@@ -89,16 +89,19 @@ void Juego::procesarTeclaPresionada(unsigned char key) // JUGADOR 1 (WASD)
 
             case Selector::JUGAR: // de momento al elegir JUGAR pasa directamente al TABLERO, falta una pantalla para elegir bando etc.
                 estadoActual = TABLERO;
-
-            case Selector::OPCIONES: // en opciones puede estar el volumen o quizá algo del juego
-                //estadoActual = OPCIONES;
-
-            case Selector::CONTROLES: // en principio muestra nuestros controles, quizá se puedan elegir los tuyos propios
-                //estadoActual = CONTROLES;
-
-            case Selector::CREDITOS:
-                //estadoActual = CREDITOS;
                 break;
+
+            //case Selector::OPCIONES: // en opciones puede estar el volumen o quizá algo del juego
+            //    estadoActual = OPCIONES; // no sé si los submenús del ménu son un estado 
+            //    break;
+
+            //case Selector::CONTROLES: // en principio muestra nuestros controles, quizá se puedan elegir los tuyos propios
+            //    estadoActual = CONTROLES;
+            //    break;
+
+            //case Selector::CREDITOS:
+            //    estadoActual = CREDITOS;
+            //    break;
             }
         }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -66,12 +66,22 @@ void Menu::dibujar(Renderizador* motor)
 	}
 
 	motor->dibujarSprite("../assets/Sprites/menu/opciones.png", 128, 128, 245, 103, -2.8); // OPCIONES
-	motor->dibujarSprite("../assets/Sprites/menu/selector.png", 16, 16, 178, 140, -3.2); // SELECTOR
+
+	selector.posy = 140 - (selector.opcionActual * 20.0f);
+	motor->dibujarSprite("../assets/Sprites/menu/selector.png", 16, 16, selector.posx, selector.posy, -3.2); // SELECTOR
 
 	motor->dibujarSprite("../assets/Sprites/menu/palomaSpritesheet.png", 128, 64, paloma.posx, paloma.posy, -3, 2, 4, paloma.frameActualX, paloma.frameActualY); // PALOMA
 	motor->dibujarSprite("../assets/Sprites/menu/tractorSpritesheet.png", 512, 128, tractor.posx, tractor.posy, -5, 1, 2, tractor.frameActualX, tractor.frameActualY); // TRACTOR
-	
 
+	
+}
+
+void Menu::moverSelector(int direccion) {
+	int nueva_opcion = selector.opcionActual + direccion;
+	
+	if (nueva_opcion >= 0 && nueva_opcion <= 3) {
+		selector.opcionActual = static_cast<Selector::Opcion>(nueva_opcion);
+	}
 }
 
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -47,6 +47,8 @@ void Menu::actualizar(float dt)
 		paloma.posx = 0.15 * ancho + titulo[0].horiz;
 		paloma.posy = 0.14444 * alto + titulo[0].altura; 
 	}
+
+	selector.posy = 140 - (selector.opcionActual * 20.0f); // SELECTOR	
 }
 
 void Menu::dibujar(Renderizador* motor)
@@ -66,10 +68,7 @@ void Menu::dibujar(Renderizador* motor)
 	}
 
 	motor->dibujarSprite("../assets/Sprites/menu/opciones.png", 128, 128, 245, 103, -2.8); // OPCIONES
-
-	selector.posy = 140 - (selector.opcionActual * 20.0f);
 	motor->dibujarSprite("../assets/Sprites/menu/selector.png", 16, 16, selector.posx, selector.posy, -3.2); // SELECTOR
-
 	motor->dibujarSprite("../assets/Sprites/menu/palomaSpritesheet.png", 128, 64, paloma.posx, paloma.posy, -3, 2, 4, paloma.frameActualX, paloma.frameActualY); // PALOMA
 	motor->dibujarSprite("../assets/Sprites/menu/tractorSpritesheet.png", 512, 128, tractor.posx, tractor.posy, -5, 1, 2, tractor.frameActualX, tractor.frameActualY); // TRACTOR
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -6,12 +6,12 @@
 
 void Menu::actualizar(float dt) 
 {
-	anguloLetras += 0.05; 
-	if (anguloLetras > 360) anguloLetras = 0; // LETRAS
+	angulo += 0.05; 
+	if (angulo > 360) angulo = 0; // LETRAS
 
 	for (int i = 0; i < 6; i++) // LETRAS 
 	{
-		titulo[i].altura = 0.73333 * alto + 0.05555 * alto * sin(anguloLetras + i / 2.0); // Desplazamientos relativos a ancho y alto
+		titulo[i].altura = 0.73333 * alto + 0.04 * alto * sin(angulo + i / 2.0); // Desplazamientos relativos a ancho y alto
 		titulo[i].horiz = 0.05625 * ancho + 0.1125 * ancho * i;
 		if (i == 0)  titulo[i].horiz -= 0.00625 * ancho; // Ajuste a la izquierda por ser la 'R' más grande
 	}
@@ -49,6 +49,7 @@ void Menu::actualizar(float dt)
 	}
 
 	selector.posy = 139 - (selector.opcionActual * 25.0f); // SELECTOR	
+	selector.tamano_actual = selector.tamano_base + 1.0f * sin(angulo * 3.0f); // latido del selector
 }
 
 void Menu::dibujar(Renderizador* motor)
@@ -68,11 +69,10 @@ void Menu::dibujar(Renderizador* motor)
 	}
 
 	motor->dibujarSprite("../assets/Sprites/menu/opciones.png", 128, 128, 245, 103, -2.8); // OPCIONES
-	motor->dibujarSprite("../assets/Sprites/menu/selector.png", 16, 16, selector.posx, selector.posy, -3.2); // SELECTOR
+	motor->dibujarSprite("../assets/Sprites/menu/selector.png", selector.tamano_actual, selector.tamano_actual, selector.posx, selector.posy, -3.2); // SELECTOR
 	motor->dibujarSprite("../assets/Sprites/menu/palomaSpritesheet.png", 128, 64, paloma.posx, paloma.posy, -3, 2, 4, paloma.frameActualX, paloma.frameActualY); // PALOMA
 	motor->dibujarSprite("../assets/Sprites/menu/tractorSpritesheet.png", 512, 128, tractor.posx, tractor.posy, -5, 1, 2, tractor.frameActualX, tractor.frameActualY); // TRACTOR
-
-	
+		
 }
 
 void Menu::moverSelector(int direccion) {

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -21,7 +21,7 @@ void Menu::actualizar(float dt)
 	if (tractor.timer > tractor.msStep)
 	{
 		if (tractor.frameActualX < 1) tractor.frameActualX++;
-		else                   tractor.frameActualX = 0;
+		else tractor.frameActualX = 0;
 		tractor.timer = tractor.timer - tractor.msStep;
 	}
 
@@ -48,7 +48,7 @@ void Menu::actualizar(float dt)
 		paloma.posy = 0.14444 * alto + titulo[0].altura; 
 	}
 
-	selector.posy = 140 - (selector.opcionActual * 20.0f); // SELECTOR	
+	selector.posy = 139 - (selector.opcionActual * 25.0f); // SELECTOR	
 }
 
 void Menu::dibujar(Renderizador* motor)

--- a/src/tablero.cpp
+++ b/src/tablero.cpp
@@ -38,8 +38,12 @@ void Tablero::inicializarTablero()//Importante, iniclizaiamos el Tablero vacio, 
 
 }
 
-void Tablero::dibujarTablero()
-{
+void Tablero::dibujarTablero(Renderizador* motor){
+
+    // imagen de fondo del tablero
+    motor->dibujarSprite("../assets/Sprites/tablero y escenario/tableroOficial.png", 198, 198, X_INICIO + (9 * 11), Y_INICIO + (9 * 11), 0);
+
+    // recorrer la matriz para dibujar casillas de poder y animales
     for (int i = 0; i < FILAS; i++)
     {
         for (int j = 0; j < COLUMNAS; j++)
@@ -49,15 +53,26 @@ void Tablero::dibujarTablero()
 
             if (esPuntoDePoder(i, j))
             {
-                //Dibujar con la libreria freglut supongo, un simbolo qeu indique que es una casilla de poder
+                // motor->dibujarSprite("../assets/Sprites/puntopoder.png", [...] )
             }
 
             if (casillas[i][j] != nullptr)
             {
-                //Casillas[i][j]->Dibujar(X, Y);//la funcion dibujar debe estar dentro de animal.h, porque aqui le decimos que nos dibuje en la casilla el animal
+                // casillas[i][j]->dibujar(motor); 
+                // la funcion dibujar debe estar dentro de animal.h, porque aqui le decimos que nos dibuje en la casilla el animal
             }
         }
     }
+
+    // dibujar los cursores
+    //float cursor1X = X_INICIO + (posicion_columna_cursor_actual_j1 * TAMANO_CASILLA) + 11.0f;
+    //float cursor1Y = Y_INICIO + (posicion_fila_cursor_actual_j1 * TAMANO_CASILLA) + 11.0f;
+    //motor->dibujarSprite("../assets/Sprites/cursorJ1.png", 22, 22, cursor1X, cursor1Y, -1.0f);
+
+    //float cursor2X = X_INICIO + (posicion_columna_cursor_actual_j2 * TAMANO_CASILLA) + 11.0f;
+    //float cursor2Y = Y_INICIO + (posicion_fila_cursor_actual_j2 * TAMANO_CASILLA) + 11.0f;
+    //motor->dibujarSprite("../assets/Sprites/cursorJ2.png", 22, 22, cursor2X, cursor2Y, -1.0f);
+
 }
 
 bool Tablero::obtenerCasillaEnLaPinchamos(int x_pantalla, int y_pantalla, int& fila, int& columna)


### PR DESCRIPTION
Implementación lógica y gráfica de la selección en el menú.
El selector consiste en un círculo a la izquierda de las opciones a elegir.
Se pude mover con las flechas y seleccionar pulsando Intro.
Al pulsar Intro en JUGAR se pasa al tablero, aunque falta un submenú para elegir bando etc.

Falta implementar la lógica del resto de opciones y oscurecer el tono rojizo de la palabra de la opción seleccionada a modo de feedback.