### PR TITLE
inclusión de arena, simulación de combate, recibe el código quién ha …

### DIFF
--- a/archon.vcxproj
+++ b/archon.vcxproj
@@ -30,26 +30,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/archon.vcxproj.filters
+++ b/archon.vcxproj.filters
@@ -48,6 +48,7 @@
     <ClInclude Include="include\llama.h" />
     <ClInclude Include="include\oveja.h" />
     <ClInclude Include="include\creditos.h" />
+    <ClInclude Include="include\controles.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="docs\cuadernoBitacora.md">
@@ -89,6 +90,7 @@
     <ClCompile Include="src\llama.cpp" />
     <ClCompile Include="src\oveja.cpp" />
     <ClCompile Include="src\creditos.cpp" />
+    <ClCompile Include="src\controles.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Library Include="lib\ETSIDI.lib">

--- a/include/arena.h
+++ b/include/arena.h
@@ -2,9 +2,26 @@
 #include "animal.h"
 #include "renderizador.h"	
 
+//dimensiones que ocupa la arena en la pantalla
+
 const int ANCHO_DE_LA_ARENA = 480;
 const int ALTO_DE_LA_ARENA = 270;
-const int NUM_DE_BARRERAS = 6;
+
+//dimensiones de la zona de combate
+const int ZONA_DE_COMBATE_X = 198;
+const int ZONA_DE_COMBATE_Y = 198;
+
+//calculo de margenes de la arena
+const float ARENA_MARGEN_X = (ANCHO_DE_LA_ARENA - ZONA_DE_COMBATE_X) / 2.0f;
+const float ARENA_MARGEN_Y = (ALTO_DE_LA_ARENA - ZONA_DE_COMBATE_Y) / 2.0f;
+
+//limites para los moves y ataques
+const float LIMITE_IZQ_ARENA = ARENA_MARGEN_X;
+const float LIMITE_DCH_ARENA = ARENA_MARGEN_X + ZONA_DE_COMBATE_X;
+const float LIMITE_ARRIBA_ARENA = ARENA_MARGEN_Y;
+const float LIMITE_ABAJO_ARENA = ARENA_MARGEN_Y + ZONA_DE_COMBATE_Y;
+
+const int NUM_DE_BARRERAS = 8;
 
 const int ARRIBA = 0;
 const int ABAJO = 1;
@@ -20,6 +37,8 @@ class Arena
 	Animal* combatientes[2]; // si quereis Bnado Luz [0], [1] para el otro bando.
 	float pos_x[2];
 	float pos_y[2];
+	float pos_antigua_x[2];
+	float pos_antigua_y[2];
 	float ultima_direccion_x[2];
 	float ultima_direccion_y[2];
 	bool vivo[2];
@@ -40,12 +59,18 @@ class Arena
 
 	float barrera_x[NUM_DE_BARRERAS];
 	float barrera_y[NUM_DE_BARRERAS];
-	float barrera_visible[NUM_DE_BARRERAS];
-	float contador_de_ciclo_barreras;
-	float ciclo_maximo_barreras;
-
+	bool barrera_visible[NUM_DE_BARRERAS];
+	float contador_ciclo_barrera[8];
+	float ciclo_maximo_barrera[8];
 	int ganador;
 	bool combate_terminado;
+
+	//atributos de ataque a melee
+	bool ataque_activo[2];
+	float ataque_x[2];
+	float ataque_y[2];
+	float ataque_visible_tiempo[2];
+	static const float DURACION_ATAQUE;
 
 	void actualizarMovimiento(float dt);
 	void actualizarDisparo(float dt);
@@ -56,6 +81,7 @@ class Arena
 	void mantenerLimites(int jugador);
 	bool colisionBarrera(float x, float y);
 	void colocarBarrerasAleatorias();
+	void actualizarAtaque(float dt);
 	
 public:
 	Arena();
@@ -66,7 +92,7 @@ public:
 	void dibujar(Renderizador* renderizador);
 	void recibirMovimiento(int jugador, int movimiento, bool tecla_pulsada);
 	bool recibirAtaque(int jugador);
-
+	int obtenerPerdedor() const; 
 	bool combateTerminado() const;
 	int ganadorCombate() const;
 };

--- a/include/gallina.h
+++ b/include/gallina.h
@@ -10,6 +10,8 @@ public:
 
 		max_casillas_movidas_ = 2;
 		nFrames = 8;
+		ataque_ = 5;
+		frameActualY_ = 0;
 		setState(0, 0);
 	}
 

--- a/include/renderizador.h
+++ b/include/renderizador.h
@@ -26,4 +26,7 @@ public:
 									// esto mejora rendimiento y evita artefactos raros entre animales
     );
 
+	void dibujarArena(float x, float y, float ancho, float alto, float r, float g, float b, float profundidad);
+	void dibujarBarreras(float x, float y, float ancho, float alto, float r, float g, float b, float profundidad);
+
 };

--- a/src/arena.cpp
+++ b/src/arena.cpp
@@ -1,8 +1,11 @@
 #include "arena.h"
 #include <cmath>
 #include <cstdlib>
+#include <ctime>
 
+const float Arena::DURACION_ATAQUE = 0.2f;
 Arena::Arena() {
+	srand(time(nullptr));
 	combatientes[0] = nullptr;
 	combatientes[1] = nullptr;
 	ganador = -1;
@@ -18,15 +21,18 @@ Arena::Arena() {
 		direccion_disparo_x[i] = direccion_disparo_y[i] = 0;
 		recarga_de_ataque[i] = 0;//tiempo que falta para poder atacar
 		recarga_maxima_de_ataque[i] = 1.0f;//tiempo que tiene que pasar para poder atacar de nuevo.
+		ataque_activo[i] = false;
+		ataque_x[i] = 0;
+		ataque_y[i] = 0;
+		ataque_visible_tiempo[i] = 0;
 	}
-	
-	contador_de_ciclo_barreras = 0;
-	ciclo_maximo_barreras = 3.0f; //las baerras se mueven cada 3 seg
 
 	for (int i = 0; i < NUM_DE_BARRERAS; i++) {
 		barrera_x[i] = 0;
 		barrera_y[i] = 0;
-		barrera_visible[i] = true;
+		ciclo_maximo_barrera[i] = 3000.0f + (rand() % 8000);
+		barrera_visible[i] = (rand() % 2 == 0);
+		contador_ciclo_barrera[i] = (float)(rand() % (int)ciclo_maximo_barrera[i]);
 	}
 }
 
@@ -39,95 +45,152 @@ void Arena::inicioCombate(Animal* pieza_luz, Animal* pieza_oscuridad)
 	combatientes[0] = pieza_luz;
 	combatientes[1] = pieza_oscuridad;
 
-	//colocacion de las piezas en la arena
-	pos_x[0] = 80.0f;  
-	pos_y[0] = ALTO_DE_LA_ARENA / 2.0f;
-	pos_x[1] = ANCHO_DE_LA_ARENA - 80.0f;
-	pos_y[1] = ALTO_DE_LA_ARENA / 2.0f;
+	// desactivamos toda la logica del tablero para estos animales
+	combatientes[0]->intro_tablero_ = false;
+	combatientes[0]->en_movimiento_ = false;
+	combatientes[0]->casillas_movidas_ = 0;
+	combatientes[0]->casillas_movidas_x_ = 0;
+	combatientes[0]->casillas_movidas_y_ = 0;
+	combatientes[0]->velx_ = 0;
+	combatientes[0]->vely_ = 0;
+
+	combatientes[1]->intro_tablero_ = false;
+	combatientes[1]->en_movimiento_ = false;
+	combatientes[1]->casillas_movidas_ = 0;
+	combatientes[1]->casillas_movidas_x_ = 0;
+	combatientes[1]->casillas_movidas_y_ = 0;
+	combatientes[1]->velx_ = 0;
+	combatientes[1]->vely_ = 0;
+
+	// colocacion en la arena
+	pos_x[0] = ARENA_MARGEN_X + 30.0f;
+	pos_y[0] = ARENA_MARGEN_Y + ZONA_DE_COMBATE_Y / 2.0f;
+	pos_x[1] = ARENA_MARGEN_X + ZONA_DE_COMBATE_X - 30.0f;
+	pos_y[1] = ARENA_MARGEN_Y + ZONA_DE_COMBATE_Y / 2.0f;
+
+	combatientes[0]->posx_ = pos_x[0];
+	combatientes[0]->posy_ = pos_y[0];
+	combatientes[1]->posx_ = pos_x[1];
+	combatientes[1]->posy_ = pos_y[1];
 
 	vivo[0] = true;
 	vivo[1] = true;
 
-	//recargamos el ataque de cada pieza
-	for (int i = 0; i < 2; i++){
-		int tipo_de_ataque = 0; //combatientes[i]->obtenerTipoDeAtaque(); //cambiar para lo de la funcion ObtenerTipoDeAtaque 
-		if (tipo_de_ataque == ATAQUE_TIPO_GOLPE) recarga_maxima_de_ataque[i] = 0.5f;
-		if (tipo_de_ataque == ATAQUE_TIPO_DISPARO)recarga_maxima_de_ataque[i] = 1.0f;
-		if (tipo_de_ataque == ATAQUE_EN_AREA) recarga_maxima_de_ataque[i] = 2.0f;
+	for (int i = 0; i < 2; i++) {
+		int tipo_de_ataque = ATAQUE_TIPO_GOLPE;
+		if (tipo_de_ataque == ATAQUE_TIPO_GOLPE)   recarga_maxima_de_ataque[i] = 0.5f;
+		if (tipo_de_ataque == ATAQUE_TIPO_DISPARO) recarga_maxima_de_ataque[i] = 1.0f;
+		if (tipo_de_ataque == ATAQUE_EN_AREA)      recarga_maxima_de_ataque[i] = 2.0f;
 		recarga_de_ataque[i] = 0;
 	}
+
 	ganador = -1;
 	combate_terminado = false;
 
 	colocarBarrerasAleatorias();
-
 }
 
 void Arena::actualizar(float dt) {
 	if (combate_terminado) return;
-
+	actualizarBarreras(dt);
 	actualizarMovimiento(dt);
 	actualizarDisparo(dt);
+	actualizarAtaque(dt);
 	actualizarRecarga(dt);
-	actualizarBarreras(dt);
 	confirmarImpacto();
 	confirmarFinCombate();
 }
 
-void Arena::dibujar(Renderizador* renderizador) {
-	//code para dibujar la arena
+void Arena::dibujar(Renderizador* renderizador)
+{
+	renderizador->dibujarArena(ARENA_MARGEN_X, ARENA_MARGEN_Y, ZONA_DE_COMBATE_X, ZONA_DE_COMBATE_Y, 0.1f, 0.2f, 0.6f, -5.0f);
+	//dibujamos torres con rectangulos
 
-	//dibujamos barreras aqui
-	for (int i = 0; i < NUM_DE_BARRERAS; i++) {
-		if (barrera_visible[i]) {
-			//code de dibujar las barreras, importante, hay que dibujar tanto barrera x[] y barrera y[]
+	for (int i = 0; i < NUM_DE_BARRERAS; i++)
+	{
+		if (barrera_visible[i])
+		{
+			renderizador->dibujarBarreras(barrera_x[i] - 7, barrera_y[i] - 9, 14, 18, 0.6f, 0.6f, 0.6f, -3.0f);
+			renderizador->dibujarBarreras(barrera_x[i] - 8, barrera_y[i] - 11, 16, 4, 0.8f, 0.8f, 0.8f, 0.1f);
+		}
+		else
+		{
+			renderizador->dibujarBarreras(barrera_x[i] - 6, barrera_y[i] - 11, 12, 3, 0.2f, 0.2f, 0.2f, -0.9f);
 		}
 	}
 
 	for (int i = 0; i < 2; i++) {
-		if (disparo_disparado[i]) {
-			//los mismo que barreras, dibujar en x e y
+		if (ataque_activo[i]) {
+			renderizador->dibujarBarreras(ataque_x[i] - 4, ataque_y[i] - 8, 8, 16, 0.55f, 0.27f, 0.07f, -2.0f);
 		}
 	}
 
+	// gallinas
+	glDisable(GL_DEPTH_TEST);
 	for (int i = 0; i < 2; i++) {
 		if (vivo[i] && combatientes[i] != nullptr) {
-			//combatientes[i]->dibujar(pos_x[i], pos_y[i]); no se porque da error
+			renderizador->dibujarSprite(
+				"../assets/Sprites/gallina/gallinaSpritesheet.png",
+				256, 32,  // doble de tamaño solo en la arena
+				combatientes[i]->posx_,
+				combatientes[i]->posy_,
+				-4.5f,
+				1, 8,
+				combatientes[i]->frameActualX_,
+				combatientes[i]->frameActualY_,
+				true
+			);
 		}
 	}
+	glEnable(GL_DEPTH_TEST);
 }
 
+
 void Arena::recibirMovimiento(int jugador, int movimiento, bool tecla_pulsada) {
-	if (movimiento == ARRIBA) movimiento_arriba[jugador] = true;
-	if (movimiento == ABAJO) movimiento_abajo[jugador] = true;
-	if (movimiento == IZQUIERDA) movimiento_izq[jugador] = true;
-	if (movimiento == DERECHA) movimiento_dch[jugador] = true;
+	if (movimiento == ARRIBA)    movimiento_arriba[jugador] = tecla_pulsada;
+	if (movimiento == ABAJO)     movimiento_abajo[jugador] = tecla_pulsada;
+	if (movimiento == IZQUIERDA) movimiento_izq[jugador] = tecla_pulsada;
+	if (movimiento == DERECHA)   movimiento_dch[jugador] = tecla_pulsada;
 }
 
 bool Arena::recibirAtaque(int jugador) {
 	if (combate_terminado) return false;
 	if (!vivo[jugador]) return false;
-
 	if (recarga_de_ataque[jugador] > 0) return false;
 
-	int tipo = 0; //combatientes[jugador]->getTipoAtaque();//getTipoAtaque la tendra animal, el cero es para que no de error
-	
+	int tipo = ATAQUE_TIPO_GOLPE; //combatientes[jugador]->getTipoAtaque();
+
 	if (tipo == ATAQUE_TIPO_DISPARO) {
 		direccion_disparo_x[jugador] = ultima_direccion_x[jugador];
 		direccion_disparo_y[jugador] = ultima_direccion_y[jugador];
 		disparo_x[jugador] = pos_x[jugador];
 		disparo_y[jugador] = pos_y[jugador];
 		disparo_disparado[jugador] = true;
+
 	}
 	else if (tipo == ATAQUE_TIPO_GOLPE) {
 		int rival = (jugador == 0) ? 1 : 0;
+
+		// colocamos el palo delante de la gallina segun donde mire
+		float offset = 18.0f;
+		ataque_x[jugador] = pos_x[jugador] + ultima_direccion_x[jugador] * offset;
+		ataque_y[jugador] = pos_y[jugador] + ultima_direccion_y[jugador] * offset;
+		ataque_activo[jugador] = true;
+		ataque_visible_tiempo[jugador] = 0;
+
+		// comprobamos si el rival esta en rango de golpe
 		float dx = pos_x[jugador] - pos_x[rival];
-		float dy = pos_x[jugador] - pos_y[rival];
+		float dy = pos_y[jugador] - pos_y[rival];
 		float dist = sqrt(dx * dx + dy * dy);
+
 		if (dist < 30.0f) {
-			//combatientes[rival]->recibirDano(combatientes[jugador]->getdano());
+			combatientes[rival]->vida_ -= combatientes[jugador]->ataque_;
+			std::cout << "Jugador " << rival + 1 << " recibe golpe. Vida restante: "
+				<< combatientes[rival]->vida_ << std::endl;
 		}
-	} else if (tipo == ATAQUE_EN_AREA) {
+
+	}
+	else if (tipo == ATAQUE_EN_AREA) {
 		int rival = (jugador == 0) ? 1 : 0;
 		float dx = pos_x[jugador] - pos_x[rival];
 		float dy = pos_y[jugador] - pos_y[rival];
@@ -135,29 +198,62 @@ bool Arena::recibirAtaque(int jugador) {
 		/*
 		* float alcance = combatientes[jugador]->getAlcance();
 		* if(dist<alcance){
-		*combatientes[rival]->recibirDano(combatientes[jugador]->getDano()); 
-		}
+		*   combatientes[rival]->recibirDano(combatientes[jugador]->getDano());
+		* }
 		*/
 	}
 
 	recarga_de_ataque[jugador] = recarga_maxima_de_ataque[jugador];
+	return true;
 }
 
 bool Arena::combateTerminado() const { return combate_terminado; }
 int Arena::ganadorCombate()const { return ganador; }
 
-void Arena::actualizarMovimiento(float dt) {
-	for (int i = 0; i < 2; i++) {
+void Arena::actualizarMovimiento(float dt)
+{
+	for (int i = 0; i < 2; i++)
+	{
 		if (!vivo[i]) continue;
 
-		float velocidad = 8; //combatientes[i]->getVelocidad(); luego hay que descomentar obvio
-		if (movimiento_arriba[i])pos_y[i] -= velocidad * dt;
-		if (movimiento_abajo[i])pos_y[i] += velocidad * dt;
-		if (movimiento_izq[i])pos_x[i] -= velocidad * dt;
-		if (movimiento_dch[i])pos_x[i] += velocidad * dt;
+		pos_antigua_x[i] = pos_x[i];
+		pos_antigua_y[i] = pos_y[i];
 
+		float velocidad = 100.0f;
+		float dt_seg = dt / 1000.0f;  // convertimos a segundos
+
+		if (movimiento_arriba[i]) pos_y[i] += velocidad * dt_seg;
+		if (movimiento_abajo[i])  pos_y[i] -= velocidad * dt_seg;
+		if (movimiento_izq[i])    pos_x[i] -= velocidad * dt_seg;
+		if (movimiento_dch[i])    pos_x[i] += velocidad * dt_seg;
+
+		if (movimiento_arriba[i]) { ultima_direccion_x[i] = 0; ultima_direccion_y[i] = 1; }
+		if (movimiento_abajo[i]) { ultima_direccion_x[i] = 0; ultima_direccion_y[i] = -1; }
+		if (movimiento_izq[i]) { ultima_direccion_x[i] = -1; ultima_direccion_y[i] = 0; }
+		if (movimiento_dch[i]) { ultima_direccion_x[i] = 1; ultima_direccion_y[i] = 0; }
+
+		if (colisionBarrera(pos_x[i], pos_y[i]))
+		{
+			pos_x[i] = pos_antigua_x[i];
+			pos_y[i] = pos_antigua_y[i];
+		}
+
+	
+		int rival = (i == 0) ? 1 : 0;
+		float dx = pos_x[i] - pos_x[rival];
+		float dy = pos_y[i] - pos_y[rival];
+		float dist = sqrt(dx * dx + dy * dy);
+		if (dist < 22.0f) 
+		{
+			pos_x[i] = pos_antigua_x[i];
+			pos_y[i] = pos_antigua_y[i];
+		}
 		mantenerLimites(i);
 
+		if (combatientes[i] != nullptr) {
+			combatientes[i]->posx_ = pos_x[i];
+			combatientes[i]->posy_ = pos_y[i];
+		}
 	}
 }
 
@@ -186,21 +282,48 @@ void Arena::actualizarDisparo(float dt) {
 void Arena::actualizarRecarga(float dt) {
 	for (int i = 0; i < 2; i++) {
 		if (recarga_de_ataque[i] > 0)
-			recarga_de_ataque[i] -= dt;
+			recarga_de_ataque[i] -= dt/1000;
 	}
 }
 
 void Arena::actualizarBarreras(float dt) {
-	// avanzamos el ciclo
-	contador_de_ciclo_barreras += dt;
-
-	if (contador_de_ciclo_barreras >= ciclo_maximo_barreras) {
-		contador_de_ciclo_barreras = 0;
-		for (int i = 0; i < NUM_DE_BARRERAS; i++) {
+	for (int i = 0; i < NUM_DE_BARRERAS; i++) {
+		contador_ciclo_barrera[i] += dt;
+		if (contador_ciclo_barrera[i] >= ciclo_maximo_barrera[i]) 
+		{
+			contador_ciclo_barrera[i] = 0.0f;
 			barrera_visible[i] = !barrera_visible[i];
+			ciclo_maximo_barrera[i] = 10000.0f + (rand() % 10);
+
+			if (barrera_visible[i]) 
+			{
+				for (int j = 0; j < 2; j++) 
+				{
+					if (!vivo[j]) continue;
+					float dx = pos_x[j] - barrera_x[i];
+					float dy = pos_y[j] - barrera_y[i];
+					if (dx > -10 && dx < 10 && dy > -12 && dy < 12) 
+					{
+						// empujamos al jugador fuera de la barrera
+						// lo movemos hacia el lado mas cercano
+						if (abs(dx) > abs(dy))
+							pos_x[j] += (dx > 0) ? 12.0f : -12.0f;
+						else
+							pos_y[j] += (dy > 0) ? 14.0f : -14.0f;
+
+						// sincronizamos con el animal
+						if (combatientes[j] != nullptr) 
+						{
+							combatientes[j]->posx_ = pos_x[j];
+							combatientes[j]->posy_ = pos_y[j];
+						}
+					}
+				}
+			}
 		}
 	}
 }
+
 
 void Arena::confirmarImpacto() {
 	for (int i = 0; i < 2; i++) {
@@ -220,39 +343,82 @@ void Arena::confirmarImpacto() {
 	}
 }
 
-void Arena::confirmarFinCombate() {
-	/*
+void Arena::confirmarFinCombate() 
+{
 	for (int i = 0; i < 2; i++) {
-		if (combatientes[i] != nullptr && combatientes[i]->getVida() <= 0) {
+		if (combatientes[i] != nullptr && combatientes[i]->vida_ <= 0) {
 			vivo[i] = false;
 			combate_terminado = true;
-			//ganador = (i == 0) ? BANDO_OSCURIDAD : BANDO_LUZ;
+			ganador = (i == 0) ? 1 : 0;
+			std::cout << "Jugador " << ganador + 1 << " gana el combate!" << std::endl;
 		}
-	}*/
+	}
 }
 
-void Arena::mantenerLimites(int jugador) {
-	if (pos_x[jugador] < 0) pos_x[jugador] = 0;
-	if (pos_x[jugador] > ANCHO_DE_LA_ARENA) pos_x[jugador] = ANCHO_DE_LA_ARENA;
-	if (pos_y[jugador] < 0) pos_y[jugador] = 0;
-	if (pos_y[jugador] > ALTO_DE_LA_ARENA) pos_y[jugador] = ALTO_DE_LA_ARENA;
+void Arena::mantenerLimites(int jugador)
+{
+	float radio = 11.0f;
+	float antes_x = pos_x[jugador];
+	float antes_y = pos_y[jugador];
+
+	if (pos_x[jugador] < ARENA_MARGEN_X + radio) pos_x[jugador] = ARENA_MARGEN_X + radio;
+	if (pos_x[jugador] > ARENA_MARGEN_X + ZONA_DE_COMBATE_X - radio) pos_x[jugador] = ARENA_MARGEN_X + ZONA_DE_COMBATE_X - radio;
+	if (pos_y[jugador] < ARENA_MARGEN_Y + radio) pos_y[jugador] = ARENA_MARGEN_Y + radio;
+	if (pos_y[jugador] > ARENA_MARGEN_Y + ZONA_DE_COMBATE_Y - radio) pos_y[jugador] = ARENA_MARGEN_Y + ZONA_DE_COMBATE_Y - radio;
+
+	if (antes_x != pos_x[jugador] || antes_y != pos_y[jugador])
+		std::cout << "LIMITE ACTIVADO J" << jugador << ": de (" << antes_x << "," << antes_y << ") a (" << pos_x[jugador] << "," << pos_y[jugador] << ")" << std::endl;
 }
 
 bool Arena::colisionBarrera(float x, float y) {
-	for (int i = 0; i < NUM_DE_BARRERAS; i++) {
+	for (int i = 0; i < NUM_DE_BARRERAS; i++) 
+	{
 		if (!barrera_visible[i]) continue;
 		float dx = x - barrera_x[i];
 		float dy = y - barrera_y[i];
-		if (dx > -20 && dx < 20 && dy > -20 && dy < 20)
+		if (dx > -10 && dx < 10 && dy > -12 && dy < 12)
 			return true;
 	}
 	return false;
 }
 
 void Arena::colocarBarrerasAleatorias() {
+	float margen = 15.0f;
+	float zona_x = (ZONA_DE_COMBATE_X - margen * 2) / 4.0f;
+	float zona_y = (ZONA_DE_COMBATE_Y - margen * 2) / 2.0f;
+
 	for (int i = 0; i < NUM_DE_BARRERAS; i++) {
-		barrera_x[i] = 100.0f + (rand() % (ANCHO_DE_LA_ARENA - 200));
-		barrera_y[i] = 40.0f + (rand() % (ALTO_DE_LA_ARENA - 80));
-		barrera_visible[i] = true;
+		int columna = i % 4;
+		int fila = i / 4;
+
+		// esquina de cada zona dentro del cuadrado azul
+		float origen_x = ARENA_MARGEN_X + margen + (columna * zona_x);
+		float origen_y = ARENA_MARGEN_Y + margen + (fila * zona_y);
+
+		// posicion aleatoria dentro de esa zona
+		barrera_x[i] = origen_x + (rand() % (int)(zona_x * 0.7f));
+		barrera_y[i] = origen_y + (rand() % (int)(zona_y * 0.7f));
+
 	}
 }
+
+void Arena::actualizarAtaque(float dt)
+{
+	for (int i = 0; i < 2; i++) {
+		if (!ataque_activo[i]) continue;
+
+		ataque_visible_tiempo[i] += dt/1000;
+
+		// el palo desaparece despues de DURACION_ATAQUE segundos
+		if (ataque_visible_tiempo[i] >= DURACION_ATAQUE)
+		{
+			ataque_activo[i] = false;
+			ataque_visible_tiempo[i] = 0;
+		}
+	}
+}
+	
+int Arena::obtenerPerdedor() const {
+	return (ganador == 0) ? 1 : 0;
+}
+

--- a/src/juego.cpp
+++ b/src/juego.cpp
@@ -67,6 +67,23 @@ void Juego::actualizarLogica(float dt) {    // FASE 1: matemáticas, colisiones 
 
     case BATALLA:
         arena->actualizar(dt);
+            if (arena->combateTerminado()) 
+            {
+                int perdedor = arena->obtenerPerdedor();
+                if (perdedor == 0) 
+                {
+                    animalesJ1[9]->vida_ = 0;
+                    animalesJ1[9]->posx_ = -100; // la mandamos fuera de pantalla
+                    animalesJ1[9]->posy_ = -100;
+                }
+                else 
+                {
+                    animalesJ2[9]->vida_ = 0;
+                    animalesJ2[9]->posx_ = -100;
+                    animalesJ2[9]->posy_ = -100;
+                }
+                estado_actual = TABLERO;
+            }
         break;
 
     case CREDITOS:
@@ -135,6 +152,13 @@ void Juego::renderizarGraficos() {          // FASE 2: pintar en pantalla
 void Juego::procesarTeclaPresionada(unsigned char key) // Hacer que tecla solo se procese si transicion.activo = false
 {
     if (key == 27) exit(0); // Esc siempre cierra el juego, aunque en un futuro molaría poner un menú de pausa
+
+    if (key == 'b' || key == 'B')
+    {
+        arena->inicioCombate(animalesJ1[9], animalesJ2[9]);
+        estado_actual = BATALLA;
+        return;
+    }
 
     switch (estado_actual) {
 
@@ -220,6 +244,7 @@ void Juego::procesarTeclaLevantada(unsigned char key)
 
 void Juego::procesarTeclaEspecialPresionada(int key) // JUGADOR 2 (FLECHAS)
 {
+ 
     switch (estado_actual) {
     case MENU:
         if (key == GLUT_KEY_UP) menu->moverSelector(-1); // arriba resta 1 (se acerca a 0 que es JUGAR)

--- a/src/renderizador.cpp
+++ b/src/renderizador.cpp
@@ -13,6 +13,7 @@ void Renderizador::dibujarSprite(const char* rutaImagen, float ancho, float alto
     float inicioFrameX = stateX * anchoFrame;
     float inicioFrameY = stateY * altoFrame;
 
+  
     glEnable(GL_TEXTURE_2D);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
@@ -50,4 +51,41 @@ void Renderizador::dibujarSprite(const char* rutaImagen, float ancho, float alto
 
     //glEnable(GL_LIGHTING);
     glDisable(GL_TEXTURE_2D);
+   
+}
+
+void Renderizador::dibujarArena(float x, float y, float ancho, float alto, float r, float g, float b, float profundidad)
+{
+    glDisable(GL_TEXTURE_2D);
+    glDisable(GL_LIGHTING);
+    glColor3f(r, g, b);
+
+    glPushMatrix();
+    glTranslatef(x + ancho / 2, y + alto / 2, profundidad);
+    glBegin(GL_POLYGON);
+        glVertex3f(-ancho / 2, -alto / 2, 0);
+        glVertex3f(ancho / 2, -alto / 2, 0);
+        glVertex3f(ancho / 2, alto / 2, 0);
+        glVertex3f(-ancho / 2, alto / 2, 0);
+    glEnd();
+    glPopMatrix();
+}
+
+void Renderizador::dibujarBarreras(float x, float y, float ancho, float alto, float r, float g, float b, float profundidad)
+{
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_TEXTURE_2D);
+    glDisable(GL_LIGHTING);
+    glColor3f(r, g, b);
+
+    glPushMatrix();
+    glTranslatef(x + ancho / 2, y + alto / 2, profundidad);
+    glBegin(GL_POLYGON);
+        glVertex3f(-ancho / 2, -alto / 2, 0);
+        glVertex3f(ancho / 2, -alto / 2, 0);
+        glVertex3f(ancho / 2, alto / 2, 0);
+        glVertex3f(-ancho / 2, alto / 2, 0);
+    glEnd();
+    glPopMatrix();
+    glEnable(GL_DEPTH_TEST);
 }


### PR DESCRIPTION
…ganado el combate y nada más terminar se vuelve al escenario de tablero. Para activar la simulación hay que apretar la B o b. La simulación inicia siempre con dos gallinas, la WASD, las flechas direccionales son los controles de movimiento de los jugadores, Q y M son las teclas de ataque de los contrincantes, hay que incluir una transición de tablero a arena, y viceversa.